### PR TITLE
[wip] add binder

### DIFF
--- a/CesiumWidget/cesiumwidget.py
+++ b/CesiumWidget/cesiumwidget.py
@@ -14,7 +14,7 @@ from traitlets import (
 class CesiumWidget(DOMWidget):
     # the name of the Backbone.View subclass to be used
     _view_name = Unicode('CesiumView', sync=True)
-    _view_module = Unicode('nbextensions/CesiumWidget/static/CesiumWidget/cesium_widget',
+    _view_module = Unicode('nbextensions/CesiumWidget/cesium_widget',
                            sync=True)
 
     czml = Tuple(sync=True)
@@ -24,7 +24,6 @@ class CesiumWidget(DOMWidget):
     _zoomto = List(sync=True, trait=Float, allow_none=True)
     _flyto = List(sync=True, trait=Float, allow_none=True)
     _zoomtoregion = List(sync=True, trait=Float, allow_none=True)
-
 
     animation = Bool(True, sync=True)
     base_layer_picker = Bool(True, sync=True)
@@ -48,6 +47,6 @@ class CesiumWidget(DOMWidget):
 
     def fly_to(self, lon, lat, alt, heading=0, pitch=-90, roll=0):
         self._flyto = [lon, lat, alt, heading, pitch, roll]
-        
+
     def zoom_to_region(self, west, south, east, north):
         self._zoomtoregion = [west, south, east, north]

--- a/CesiumWidget/static/CesiumWidget/cesium_widget.js
+++ b/CesiumWidget/static/CesiumWidget/cesium_widget.js
@@ -7,7 +7,7 @@
  * @license Apache
  */
 
-var cesium_root = IPython.notebook.base_url + 'nbextensions/CesiumWidget/static/CesiumWidget/cesium/Source';
+var cesium_root = IPython.notebook.base_url + 'nbextensions/CesiumWidget/cesium/Source';
 var cesium_path = cesium_root + '/Cesium';
 
 require.config({
@@ -232,7 +232,7 @@ define(
 				}
 				console.log(pos);
             },
-            
+
             zoom_to_region: function () {
             	console.log('view region!');
 				// move the camera to a location

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,4 @@ RUN git clone https://github.com/bollwyvl/CesiumWidget.git --depth=1
 WORKDIR CesiumWidget
 
 RUN pip install .
+RUN jupyter nbextension install CesiumWidget --user

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN git clone https://github.com/bollwyvl/CesiumWidget.git --depth=1
 WORKDIR CesiumWidget
 
 RUN pip install .
-RUN jupyter nbextension install CesiumWidget --user
+RUN jupyter nbextension install CesiumWidget --user --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
 FROM andrewosh/binder-base
 
+# no root stuff to do!
 USER main
+
+# install demo support
+RUN conda install \
+    ipywidgets \
+    numpy \
+  && pip install \
+    czml \
+    geocoder
 
 # TODO: change this to `petrushy`
 RUN git clone https://github.com/bollwyvl/CesiumWidget.git --depth=1
 
 WORKDIR CesiumWidget
 
-RUN pip install .
+RUN python setup.py install
+# jupyter-pip so crazy. this is cheating, as a real user wouldn't have
+# the source checked out...
 RUN jupyter nbextension install CesiumWidget --user --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ WORKDIR CesiumWidget
 RUN python setup.py install
 # jupyter-pip so crazy. this is cheating, as a real user wouldn't have
 # the source checked out...
-RUN jupyter nbextension install CesiumWidget --user --quiet
+RUN jupyter nbextension install CesiumWidget/static/CesiumWidget --user --quiet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM andrewosh/binder-base
+
+USER main
+
+# TODO: change this to `petrushy`
+RUN git clone https://github.com/bollwyvl/CesiumWidget.git --depth=1
+
+WORKDIR CesiumWidget
+
+RUN pip install .

--- a/Examples/CesiumWidget Example KML.ipynb
+++ b/Examples/CesiumWidget Example KML.ipynb
@@ -12,12 +12,12 @@
    "metadata": {},
    "source": [
     "If the installation of Cesiumjs is ok, it should be reachable here:\n",
-    "http://localhost:8888/nbextensions/CesiumWidget/static/CesiumWidget/cesium/index.html\n"
+    "http://localhost:8888/nbextensions/CesiumWidget/cesium/index.html"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 15,
    "metadata": {
     "collapsed": true
    },
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -73,13 +73,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "cesium.kml_url = '/nbextensions/CesiumWidget/static/CesiumWidget/cesium/Apps/SampleData/kml/gdpPerCapita2008.kmz'"
+    "cesium.kml_url = '/nbextensions/CesiumWidget/cesium/Apps/SampleData/kml/gdpPerCapita2008.kmz'"
    ]
   },
   {
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 20,
    "metadata": {
     "collapsed": false
    },
@@ -114,7 +114,7 @@
        "[359.5, 0.0, 36000000.0, 0.0, -90.0, 0.0]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -162,35 +162,26 @@
    "source": [
     "cesium._flyto"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,

--- a/Examples/CesiumWidget Example with CZML library.ipynb
+++ b/Examples/CesiumWidget Example with CZML library.ipynb
@@ -13,12 +13,12 @@
    "metadata": {},
    "source": [
     "If the CesiumWidget is installed correctly, Cesium should be accessable at:\n",
-    "http://localhost:8888/nbextensions/CesiumWidget/static/CesiumWidget/cesium/index.html\n"
+    "http://localhost:8888/nbextensions/CesiumWidget/cesium/index.html"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 12,
    "metadata": {
     "collapsed": true
    },
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -99,34 +99,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "TraitError",
-     "evalue": "The 'czml' trait of a CesiumWidget instance must be a tuple, but a value of type 'instancemethod' (i.e. <bound method CZML.dumps of <czml.czml.CZML object at 0x0000000004107A20>>) was specified.",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mTraitError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-10-d0cd1227525c>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mcesiumExample\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mCesiumWidget\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mwidth\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;34m\"100%\"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mczml\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mdoc\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdumps\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\ipywidgets\\widgets\\widget.pyc\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, *pargs, **kwargs)\u001b[0m\n\u001b[0;32m    503\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    504\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m*\u001b[0m\u001b[0mpargs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 505\u001b[1;33m         \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mDOMWidget\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m*\u001b[0m\u001b[0mpargs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    506\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    507\u001b[0m         \u001b[1;32mdef\u001b[0m \u001b[0m_validate_border\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mold\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mnew\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\ipywidgets\\widgets\\widget.pyc\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, **kwargs)\u001b[0m\n\u001b[0;32m    170\u001b[0m         \u001b[1;34m\"\"\"Public constructor\"\"\"\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    171\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_model_id\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mkwargs\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'model_id'\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mNone\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 172\u001b[1;33m         \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mWidget\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    173\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    174\u001b[0m         \u001b[0mWidget\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_call_widget_constructed\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\traitlets\\config\\configurable.pyc\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, **kwargs)\u001b[0m\n\u001b[0;32m     72\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     73\u001b[0m         \u001b[1;31m# load kwarg traits, other than config\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 74\u001b[1;33m         \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mConfigurable\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     75\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     76\u001b[0m         \u001b[1;31m# load config\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\traitlets\\traitlets.pyc\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, *args, **kw)\u001b[0m\n\u001b[0;32m    586\u001b[0m         \u001b[1;32mwith\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mhold_trait_notifications\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    587\u001b[0m             \u001b[1;32mfor\u001b[0m \u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m \u001b[1;32min\u001b[0m \u001b[0miteritems\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mkw\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 588\u001b[1;33m                 \u001b[0msetattr\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    589\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    590\u001b[0m     \u001b[1;33m@\u001b[0m\u001b[0mcontextlib\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mcontextmanager\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\traitlets\\traitlets.pyc\u001b[0m in \u001b[0;36m__set__\u001b[1;34m(self, obj, value)\u001b[0m\n\u001b[0;32m    448\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    449\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0m__set__\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 450\u001b[1;33m         \u001b[0mnew_value\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_validate\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    451\u001b[0m         \u001b[1;32mtry\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    452\u001b[0m             \u001b[0mold_value\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mobj\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_trait_values\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\traitlets\\traitlets.pyc\u001b[0m in \u001b[0;36m_validate\u001b[1;34m(self, obj, value)\u001b[0m\n\u001b[0;32m    469\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    470\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mhasattr\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'validate'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 471\u001b[1;33m             \u001b[0mvalue\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mvalidate\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    472\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mobj\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_cross_validation_lock\u001b[0m \u001b[1;32mis\u001b[0m \u001b[0mFalse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    473\u001b[0m             \u001b[0mvalue\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_cross_validate\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\traitlets\\traitlets.pyc\u001b[0m in \u001b[0;36mvalidate\u001b[1;34m(self, obj, value)\u001b[0m\n\u001b[0;32m   1540\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_cast_types\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1541\u001b[0m             \u001b[0mvalue\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mklass\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1542\u001b[1;33m         \u001b[0mvalue\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msuper\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mContainer\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mvalidate\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1543\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mvalue\u001b[0m \u001b[1;32mis\u001b[0m \u001b[0mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1544\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\traitlets\\traitlets.pyc\u001b[0m in \u001b[0;36mvalidate\u001b[1;34m(self, obj, value)\u001b[0m\n\u001b[0;32m   1043\u001b[0m             \u001b[1;32mreturn\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1044\u001b[0m         \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1045\u001b[1;33m             \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0merror\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1046\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1047\u001b[0m     \u001b[1;32mdef\u001b[0m \u001b[0minfo\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32mC:\\Users\\phy\\AppData\\Local\\Continuum\\Anaconda\\envs\\work2\\lib\\site-packages\\traitlets\\traitlets.pyc\u001b[0m in \u001b[0;36merror\u001b[1;34m(self, obj, value)\u001b[0m\n\u001b[0;32m    897\u001b[0m                 \u001b[1;33m%\u001b[0m \u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mmsg\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    898\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 899\u001b[1;33m         \u001b[1;32mraise\u001b[0m \u001b[0mTraitError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0me\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    900\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    901\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mTraitError\u001b[0m: The 'czml' trait of a CesiumWidget instance must be a tuple, but a value of type 'instancemethod' (i.e. <bound method CZML.dumps of <czml.czml.CZML object at 0x0000000004107A20>>) was specified."
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "cesiumExample = CesiumWidget(width=\"100%\", czml=doc.dumps)"
+    "cesiumExample = CesiumWidget(width=\"100%\", czml=tuple(doc.data()))"
    ]
   },
   {
@@ -138,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -146,35 +125,26 @@
    "source": [
     "cesiumExample"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,

--- a/Examples/CesiumWidget Example.ipynb
+++ b/Examples/CesiumWidget Example.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -25,42 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the installation of Cesiumjs is ok, it should be reachable [here](http://localhost:8888/nbextensions/CesiumWidget/static/CesiumWidget/cesium/index.html).\n",
-    "\n",
-    "Here's an iframe to test it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <iframe\n",
-       "            width=\"100%\"\n",
-       "            height=\"500\"\n",
-       "            src=\"http://localhost:8888/nbextensions/CesiumWidget/static/CesiumWidget/cesium/index.html\"\n",
-       "            frameborder=\"0\"\n",
-       "            allowfullscreen\n",
-       "        ></iframe>\n",
-       "        "
-      ],
-      "text/plain": [
-       "<IPython.lib.display.IFrame at 0x41ca550>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "display.IFrame(\"http://localhost:8888/nbextensions/CesiumWidget/static/CesiumWidget/cesium/index.html\", width=\"100%\", height=\"500\")"
+    "If the installation of Cesiumjs is ok, it should be reachable [here](http://localhost:8888/nbextensions/CesiumWidget/cesium/index.html)."
    ]
   },
   {
@@ -74,7 +39,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
@@ -157,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -170,12 +135,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load data for the viewer to display in the [CZML](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Guide) format."
+    "Load data for the viewer to display in the [CZML](https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Guide) format, which is based on JSON. It always expects a list of Packet objects."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -184,26 +149,33 @@
     "from CesiumWidget.examples.iss import ISS\n",
     "cesium.czml = ISS"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use the excellent `czml` module to generate valid CZML: see an [example here](./CesiumWidget Example with CZML library.ipynb)."
+   ]
   }
  ],
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,10 @@
-include CesiumWidget/static/*
+include LICENSE
+include *.rst
+include *.md
+
+recursive-include CesiumWidget *
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+recursive-exclude node_modules *.*
+recursive-exclude * .git

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Join the chat at https://gitter.im/epifanio/CesiumWidget](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/epifanio/CesiumWidget?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 CesiumWidget
 ===============================
-z
 This is an IPython widget based on [Cesiumjs](http://cesiumjs.org/), a javascript
 world globe widget.
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,24 @@
 [![Join the chat at https://gitter.im/epifanio/CesiumWidget](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/epifanio/CesiumWidget?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 CesiumWidget
 ===============================
-
-This is an IPython widget based on [Cesiumjs](http://cesiumjs.org/), a javascript 
+z
+This is an IPython widget based on [Cesiumjs](http://cesiumjs.org/), a javascript
 world globe widget.
 
 For license on Cesiumjs see http://cesiumjs.org/index.html
 
 CesiumWidget part of code is under Apache license
 
+Try it Now
+----------
+[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/petrushy/CesiumWidget)
+
+
 Features
 --------
 The widget is in development and has currently basic features such as CZML and KML.
 
-The vision is to have a widget for representing orbits, 
+The vision is to have a widget for representing orbits,
 geo-related informations in an efficient way directly in the browser. By using the full
 screen button, the widget can be expanded to provide a larger view.
 

--- a/index.ipynb
+++ b/index.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# [CesiumWidget](https://github.com/petrushy/CesiumWidget)\n",
+    "Try one of the examples below!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "- ## [CesiumWidget Example KML](Examples/CesiumWidget Example KML.ipynb)\n",
+       "- ## [CesiumWidget Example with CZML library](Examples/CesiumWidget Example with CZML library.ipynb)\n",
+       "- ## [CesiumWidget Example](Examples/CesiumWidget Example.ipynb)"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# just generating the list here, nothing to see...\n",
+    "from IPython.display import Markdown\n",
+    "from glob import glob\n",
+    "Markdown(\"\\n\".join([\n",
+    "    \"- ## [{}]({})\".format(x[9:-6].replace(\"_\", \" \"), x)\n",
+    "    for x in sorted(glob(\"Examples/*.ipynb\"))\n",
+    "]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Screenshot\n",
+    "![](./screenshot.jpg)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,16 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
+# This section installs the jupyter-pip if not installed
+try:
+    from jupyterpip import cmdclass
+except:
+    import pip
+    import importlib
+
+    pip.main(['install', 'jupyter-pip'])
+    cmdclass = importlib.import_module('jupyterpip').cmdclass
+
 readme = open('README.md').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
@@ -14,7 +24,8 @@ setup(
     author_email='petrus.hyvonen@gmail.com',
     url='https://github.com/petrushy/CesiumWidget',
     packages=['CesiumWidget'],
-    install_requires=['ipywidgets'],
+    install_requires=['jupyter-pip', 'ipywidgets'],
+    cmdclass=cmdclass('CesiumWidget', user=True),
     include_package_data=True,
     license="Apache",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
+from setuptools import setup
 
 readme = open('README.md').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
@@ -13,7 +13,8 @@ setup(
     author='Petrus Hyvonen',
     author_email='petrus.hyvonen@gmail.com',
     url='https://github.com/petrushy/CesiumWidget',
-    packages=find_packages(),
+    packages=['CesiumWidget'],
+    install_requires=['ipywidgets'],
     include_package_data=True,
     license="Apache",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,6 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
 
-# This section installs the jupyter-pip if not installed
-try:
-    from jupyterpip import cmdclass
-except:
-    import pip
-    import importlib
-
-    pip.main(['install', 'jupyter-pip'])
-    cmdclass = importlib.import_module('jupyterpip').cmdclass
-
 readme = open('README.md').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
@@ -24,8 +14,7 @@ setup(
     author_email='petrus.hyvonen@gmail.com',
     url='https://github.com/petrushy/CesiumWidget',
     packages=['CesiumWidget'],
-    install_requires=['jupyter-pip', 'ipywidgets'],
-    cmdclass=cmdclass('CesiumWidget', user=True),
+    install_requires=['ipywidgets'],
     include_package_data=True,
     license="Apache",
     zip_safe=False,


### PR DESCRIPTION
This adds a continuous demo with [binder[(http://mybinder.org), a free, convenient Docker/Kubernetes-baed hosting service. This makes trying out a new, potentially complex (or in-development) feature effortless for users: they just click a link like this one:

[![Binder](http://mybinder.org/badge.svg)](http://mybinder.org/repo/bollwyvl/CesiumWidget) (this PR branch, should work already!)

Each user gets an ephemeral server and any number of kernels based on the most recent commit of  `master`.

### integration points
- `README.md` gets a pretty badge. it's already pointing at the correct repo, which won't work right now
- `index.ipynb` is the "home page" which is friendlier than getting dumped into the file browser. I've set up a slightly ugly one, but it gets the job done. A better one would actually be a hand-maintained bunch of screenshots, etc. and probably have the basic example already loaded, potentially even with some dirty tricks to start it immediately... i would suggest a tabbed widget for a simpler widget, but it's not a good idea to start too many cesiums (cesia?), i have learned.
- `Dockerfile` takes care of the installation of all of the demo-related things. It's not really very usable as a standalone Docker image, and local testing is almost pointless
  - some projects, like bqplot, have opted to have a [separate repo](https://github.com/SylvainCorlay/bqplot-binder) for the binder. this is best done _after_ the project already ships version (i.e. pypi) as then you don't have to monkey around with the dockerfile and can just use a `requirements.txt`. but in-repo has a lot of advantages, and maybe the integration can be made less noisy... considering an upstream PR
  - :warning: this pointing at my repo right now, and would need to be fixed prior to merging

### breaking changes
`jupyter-pip` isn't so good, as it's hard to anticipate what a user will want. there are some _more_ upstream PRs needed to figure this stuff out. bqplot just takes the opinion that the user should install their own assets, in the notebook. anyhow... this isn't a thing to worry too much about there is actually a shipped package, but for now I've taken jupyter-pip out.

### remaining work
- binder hosts the notebook on a subpath, like `/123341231231/notebooks/` so the paths are broken for the kml example. i haven't figured out yet how to get the information reliably, as using `../../` makes the flag assets break.
- change the source checkout to the real repo!

cc @epifanio 